### PR TITLE
Compatibility with bash 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release history for bash-complete-partial-path
 
+## v1.1.0-dev (unreleased)
+
+Development version. Work is being done on adding support for bash 3.2 (issue #8)
+
+
 ## v1.0.0 (2019-12-04)
 
 The project has been around for a long time, but no formal releases were

--- a/bash_completion
+++ b/bash_completion
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# bash-complete-partial-path                                    v1.0.0
+# bash-complete-partial-path                                 v1.1.0-dev
 #
 # Zsh-like expansion of incomplete file paths for Bash.
 # Source this file from your ~/.bashrc and use `_bcpp --defaults`

--- a/bash_completion
+++ b/bash_completion
@@ -129,9 +129,6 @@ _bcpp_complete() {
 
     # Prepare the reply
     COMPREPLY=()
-    compopt -o nospace
-    compopt -o bashdefault
-    compopt -o default
 
     # If input is already a valid path, do not try to be clever
     if [[ -e "$INPUT" ]]
@@ -193,7 +190,7 @@ _bcpp_complete_file() { _bcpp_complete file; }
 
 # Manage enhanced path completion
 _bcpp() {
-    local DEFAULT ALL KEYS ARG USAGE UNKNOWN
+    local DEFAULT ALL KEYS ARG USAGE UNKNOWN COMP_OPTIONS
 
     DEFAULT="--files --dirs --cooperate --nocase --readline"
     ALL="--files --dirs --cooperate --nocase --readline"
@@ -242,6 +239,7 @@ _bcpp() {
         "to the extent permitted by applicable law. For more information see:"
         "<http://www.apache.org/licenses/LICENSE-2.0>"
     )
+    COMP_OPTIONS="-o nospace -o bashdefault -o default"
 
     # Modify selected features list
     for ARG in "$@"
@@ -336,12 +334,12 @@ _bcpp() {
     then
         # Do not overwrite default completion function if dynamic completion
         # loader is enabled
-        [[ -z "$DYNAMIC" ]] && complete -D -F _bcpp_complete_file
+        [[ -z "$DYNAMIC" ]] && complete -D $COMP_OPTIONS -F _bcpp_complete_file
     fi
     if [[ "$KEYS" == *d* ]]  # --dirs
     then
-        complete -F _bcpp_complete_dir cd
-        complete -F _bcpp_complete_dir pushd
+        complete $COMP_OPTIONS -F _bcpp_complete_dir cd
+        complete $COMP_OPTIONS -F _bcpp_complete_dir pushd
     fi
     if [[ "$KEYS" == *c* ]]  # --nocase
     then


### PR DESCRIPTION
Work on #8 is being done here.

## Progress report

Adding support for bash 3.2 turns out to be pretty tricky. The following problems need to be solved:

- [ ] **bash 3.2 does not support `-D` flag for `complete` builtin**. It allows to call custom completion functions while completing commands that are not known beforehand
    - [ ] Were there any workarounds at that time? Or did people just hardcode completions for all possible commands?
    - [ ] How did the main [bash-completion] project work at that time? They've dropped bash < 4.1 in version 1.90
- [x] **bash 3.2 does not have `compopt` builtin (added in 4.0)** - workaround in 1a96dcf2a01f93adbffbf8476ce7c4ea96c28fd6
- [ ] **readline option `show-all-if-ambiguous` does not work** - seems to be that way only when both `menu-complete` and `show-all-if-ambiguous` are in use

[bash-completion]: https://github.com/scop/bash-completion


## Development environment

Here is a Dockerfile for convenient interactive testing on `old-bash` branch:

```Dockerfile
FROM ghcr.io/sio/bash-complete-partial-path:bash-3.2

RUN apt-get -y install git && \
    apt-get clean

WORKDIR /workdir
ADD https://gist.github.com/sio/e4f50386ef41188529e176b741132072/raw/Makefile .

ENV PY python3
ENV REPO_BRANCH old-bash
```

Usage:

```
$ docker build --rm -t oldbash -
...paste the Dockerfile, send EOF with Ctrl+D...
$ docker run -it oldbash
bash-3.2# make test
...will fetch bash-complete-partial-path, checkout the correct branch and execute automated tests...
bash-3.2# source bcpp/bash_completion && _bcpp --defaults
...to try the completion interactively...
```