### PR TITLE
#27 Honour dynamic completion loading when it's done with python3-argcomplete

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -313,7 +313,7 @@ _bcpp() {
     if [[ "$KEYS" == *o* ]]  # --cooperate|--override
     then
         local DYNAMIC
-        DYNAMIC=$(complete -p|grep -E -- '-D.*_completion_loader|_completion_loader.*-D')
+        DYNAMIC=$(complete -p|grep -E -- '-D.*_completion_loader|_completion_loader.*-D|_python_argcomplete_global.*-D')
 
         local _bcpp_filedir_original_code
         _bcpp_filedir_original_code=$(declare -f _filedir|tail -n+2)


### PR DESCRIPTION
Fixes #27 
Accept the function _python_argcomplete_global as the function to load completion dynamicly. 